### PR TITLE
Supporting mountebank running on different base URLs

### DIFF
--- a/javabank-client/src/main/java/org/mbtest/javabank/Client.java
+++ b/javabank-client/src/main/java/org/mbtest/javabank/Client.java
@@ -10,20 +10,38 @@ import org.json.simple.parser.ParseException;
 
 public class Client {
 
-    public static final String BASE_URL = "http://localhost:2525";
+    static final String DEFAULT_BASE_URL = "http://localhost:2525";
 
-    public static boolean isMountebankRunning() {
+    protected String baseUrl;
+
+    public Client() {
+        this(DEFAULT_BASE_URL);
+    }
+
+    public Client(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public Client(String host, int port) {
+        this.baseUrl = String.format("http://%s:%i", host, port);
+    }
+
+    public String getBaseUrl(){
+        return baseUrl;
+    }
+
+    public boolean isMountebankRunning() {
         try {
-            HttpResponse<JsonNode> response = Unirest.get(BASE_URL).asJson();
+            HttpResponse<JsonNode> response = Unirest.get(baseUrl).asJson();
             return response.getStatus() == 200;
         } catch (UnirestException e) {
             return false;
         }
     }
 
-    public static int createImposter(Imposter imposter) {
+    public int createImposter(Imposter imposter) {
         try {
-            HttpResponse<JsonNode> response = Unirest.post(BASE_URL + "/imposters").body(imposter.toString()).asJson();
+            HttpResponse<JsonNode> response = Unirest.post(baseUrl + "/imposters").body(imposter.toString()).asJson();
             return response.getStatus();
         }
         catch (UnirestException e) {
@@ -31,9 +49,9 @@ public class Client {
         }
     }
 
-    public static String deleteImposter(int port) {
+    public String deleteImposter(int port) {
         try {
-            HttpResponse<JsonNode> response = Unirest.delete(BASE_URL + "/imposters/" + port).asJson();
+            HttpResponse<JsonNode> response = Unirest.delete(baseUrl + "/imposters/" + port).asJson();
             return response.getBody().toString();
         }
         catch (UnirestException e) {
@@ -41,9 +59,9 @@ public class Client {
         }
     }
 
-    public static int getImposterCount() {
+    public int getImposterCount() {
         try {
-            HttpResponse<JsonNode> response = Unirest.get(BASE_URL + "/imposters").asJson();
+            HttpResponse<JsonNode> response = Unirest.get(baseUrl + "/imposters").asJson();
             return ((JSONArray)response.getBody().getObject().get("imposters")).length();
         }
         catch (UnirestException e) {
@@ -51,9 +69,9 @@ public class Client {
         }
     }
 
-    public static int deleteAllImposters() {
+    public int deleteAllImposters() {
         try {
-            HttpResponse<JsonNode> response = Unirest.delete(BASE_URL + "/imposters").asJson();
+            HttpResponse<JsonNode> response = Unirest.delete(baseUrl + "/imposters").asJson();
             return response.getStatus();
         }
         catch (UnirestException e) {
@@ -61,9 +79,9 @@ public class Client {
         }
     }
 
-    public static Imposter getImposter(int port) throws ParseException {
+    public Imposter getImposter(int port) throws ParseException {
         try {
-            HttpResponse<JsonNode> response = Unirest.get(BASE_URL + "/imposters/" + port).asJson();
+            HttpResponse<JsonNode> response = Unirest.get(baseUrl + "/imposters/" + port).asJson();
             String responseJson = response.getBody().toString();
 
             return ImposterParser.parse(responseJson);

--- a/javabank-client/src/test/java/org/mbtest/javabank/ClientTest.java
+++ b/javabank-client/src/test/java/org/mbtest/javabank/ClientTest.java
@@ -12,35 +12,43 @@ import static org.assertj.core.api.Fail.fail;
 
 @Ignore
 public class ClientTest {
+
+    private static final Client client = new Client();
+
     @Before
     public void setUp() {
         assertThatMountebankIsRunning();
-        Client.deleteAllImposters();
+        client.deleteAllImposters();
     }
 
     private void assertThatMountebankIsRunning() {
-        if(!Client.isMountebankRunning()) {
+        if(!client.isMountebankRunning()) {
             fail("Mountebank is not running!");
         }
     }
 
     @Test
+    public void shouldUseDefaultBaseUrlForDefaultConstructor() {
+        assertThat(client.getBaseUrl()).isEqualTo(Client.DEFAULT_BASE_URL);
+    }
+
+    @Test
     public void shouldVerifyMountebankIsRunning() {
-        assertThat(Client.isMountebankRunning()).isEqualTo(true);
+        assertThat(client.isMountebankRunning()).isEqualTo(true);
     }
 
     @Test
     public void shouldCreateAnImposter() {
-        int statusCode = Client.createImposter(new ImposterBuilder().onPort(5656).build());
+        int statusCode = client.createImposter(new ImposterBuilder().onPort(5656).build());
         assertThat(statusCode).isEqualTo(201);
     }
 
     @Test
     public void shouldDeleteAnImposter() {
         Imposter imposter = new ImposterBuilder().onPort(5757).build();
-        Client.createImposter(imposter);
+        client.createImposter(imposter);
 
-        String response = Client.deleteImposter(5757);
+        String response = client.deleteImposter(5757);
 
         assertThat(response)
                 .contains("5757")
@@ -49,20 +57,20 @@ public class ClientTest {
 
     @Test
     public void shouldCountTheNumberOfImposters() {
-        Client.createImposter(new ImposterBuilder().onPort(5858).build());
-        Client.createImposter(new ImposterBuilder().onPort(5959).build());
-        Client.createImposter(new ImposterBuilder().onPort(6060).build());
+        client.createImposter(new ImposterBuilder().onPort(5858).build());
+        client.createImposter(new ImposterBuilder().onPort(5959).build());
+        client.createImposter(new ImposterBuilder().onPort(6060).build());
 
-        assertThat(Client.getImposterCount()).isEqualTo(3);
+        assertThat(client.getImposterCount()).isEqualTo(3);
     }
 
     @Test
     public void shouldDeleteAllImposters() {
-        Client.createImposter(new ImposterBuilder().onPort(6060).build());
-        Client.createImposter(new ImposterBuilder().onPort(6161).build());
+        client.createImposter(new ImposterBuilder().onPort(6060).build());
+        client.createImposter(new ImposterBuilder().onPort(6161).build());
 
-        assertThat(Client.deleteAllImposters()).isEqualTo(200);
-        assertThat(Client.getImposterCount()).isEqualTo(0);
+        assertThat(client.deleteAllImposters()).isEqualTo(200);
+        assertThat(client.getImposterCount()).isEqualTo(0);
     }
 
     @Test
@@ -82,9 +90,9 @@ public class ClientTest {
                 .end()
             .end()
         .build();
-        Client.createImposter(expectedImposter);
+        client.createImposter(expectedImposter);
 
-        Imposter actualImposter = Client.getImposter(6262);
+        Imposter actualImposter = client.getImposter(6262);
 
         assertThat(actualImposter.getPort()).isEqualTo(expectedImposter.getPort());
 //        assertThat(actualImposter.getStubs()).isEqualTo(expectedImposter.getStubs());


### PR DESCRIPTION
I know this is an backward incompatible proposal. Because `Client` does no longer have static methods.

However we need support for mountebank running on non-standard base urls.

I hope you will support non standard base urls one way or the other.