### PR TITLE
support binary responses

### DIFF
--- a/javabank-core/src/main/java/org/mbtest/javabank/fluent/IsBuilder.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/fluent/IsBuilder.java
@@ -13,6 +13,7 @@ public class IsBuilder implements FluentBuilder {
     private ResponseBuilder parent;
     private int statusCode = 200;
     private String body = "";
+    private String mode;
     private File bodyFile;
     private final HashMap<String, String> headers = newHashMap();
 
@@ -40,6 +41,11 @@ public class IsBuilder implements FluentBuilder {
         return this;
     }
 
+    public IsBuilder mode(String mode){
+        this.mode = mode;
+        return this;
+    }
+
     public ResponseBuilder end() {
         return parent;
     }
@@ -55,7 +61,7 @@ public class IsBuilder implements FluentBuilder {
             }
         }
 
-        Is is = new Is().withStatusCode(statusCode).withHeaders(headers).withBody(body);
+        Is is = new Is().withStatusCode(statusCode).withHeaders(headers).withBody(body).withMode(mode);
         return is;
     }
 }

--- a/javabank-core/src/main/java/org/mbtest/javabank/http/core/Is.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/http/core/Is.java
@@ -6,6 +6,7 @@ import org.json.simple.JSONObject;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static com.google.common.collect.Maps.newHashMap;
 
@@ -14,6 +15,7 @@ public class Is extends HashMap {
     public static final String HEADERS = "headers";
     public static final String BODY = "body";
     public static final String STATUS_CODE = "statusCode";
+    public static final String MODE = "_mode";
 
     private final HashMap<String, Object> data;
     private HashMap<String, String> headers;
@@ -52,6 +54,13 @@ public class Is extends HashMap {
         return this;
     }
 
+    public Is withMode(String mode){
+        if(!Objects.isNull(mode)) {
+            this.data.put(MODE, mode);
+        }
+        return this;
+    }
+
     public String toString() {
         return toJSON().toJSONString();
     }
@@ -82,5 +91,9 @@ public class Is extends HashMap {
 
     public String getBody() {
         return (String) this.data.get(BODY);
+    }
+
+    public String getMode() {
+        return (String) this.data.get(MODE);
     }
 }

--- a/javabank-core/src/test/java/org/mbtest/javabank/http/core/IsTest.java
+++ b/javabank-core/src/test/java/org/mbtest/javabank/http/core/IsTest.java
@@ -6,6 +6,7 @@ import org.apache.http.HttpStatus;
 import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
+import org.mbtest.javabank.fluent.IsBuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -62,6 +63,19 @@ public class IsTest {
         Is is = new Is().withBody(expectedBody);
 
         assertThat(is.getBody()).isEqualTo(expectedBody);
+    }
+
+    @Test
+    public void shouldSetTheMode(){
+        Is is = new Is().withMode("binary");
+        assertThat(is.getMode()).isEqualTo("binary");
+    }
+
+    @Test
+    public void shouldNotSetAModeByDefault() throws Exception {
+        Is is = new Is();
+        assertThat(is.getMode()).isNull();
+        assertThat(is.getJSON().containsKey(Is.MODE)).isFalse();
     }
 
     @Test


### PR DESCRIPTION
While not well documented, mountebank will support binary http responses so long as the response "_mode" is set to binary and the body is a base64 encoded string.

[http://www.mbtest.org/docs/protocols/http](http://www.mbtest.org/docs/protocols/http) 