### PR TITLE
Inject Response type

### DIFF
--- a/javabank-client/src/main/java/org/mbtest/javabank/Client.java
+++ b/javabank-client/src/main/java/org/mbtest/javabank/Client.java
@@ -4,9 +4,9 @@ import com.mashape.unirest.http.HttpResponse;
 import com.mashape.unirest.http.JsonNode;
 import com.mashape.unirest.http.Unirest;
 import com.mashape.unirest.http.exceptions.UnirestException;
-import org.mbtest.javabank.http.imposters.Imposter;
 import org.json.JSONArray;
 import org.json.simple.parser.ParseException;
+import org.mbtest.javabank.http.imposters.Imposter;
 
 public class Client {
 
@@ -34,6 +34,15 @@ public class Client {
         try {
             HttpResponse<JsonNode> response = Unirest.get(baseUrl).asJson();
             return response.getStatus() == 200;
+        } catch (UnirestException e) {
+            return false;
+        }
+    }
+
+    public boolean isMountebankAllowingInjection() {
+        try {
+            HttpResponse<JsonNode> response = Unirest.get(baseUrl + "/config").asJson();
+            return response.getBody().getObject().getJSONObject("options").getBoolean("allowInjection");
         } catch (UnirestException e) {
             return false;
         }

--- a/javabank-core/src/main/java/org/mbtest/javabank/fluent/AbstractResponseBuilder.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/fluent/AbstractResponseBuilder.java
@@ -1,0 +1,18 @@
+package org.mbtest.javabank.fluent;
+
+import java.util.HashMap;
+
+public abstract class AbstractResponseBuilder implements FluentBuilder {
+    private ResponseBuilder parent;
+
+    protected AbstractResponseBuilder(ResponseBuilder parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public ResponseBuilder end() {
+        return parent;
+    }
+
+    abstract protected HashMap build();
+}

--- a/javabank-core/src/main/java/org/mbtest/javabank/fluent/InjectBuilder.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/fluent/InjectBuilder.java
@@ -2,7 +2,7 @@ package org.mbtest.javabank.fluent;
 
 import org.mbtest.javabank.http.responses.Inject;
 
-public class InjectBuilder extends AbstractResponseBuilder {
+public class InjectBuilder extends ResponseTypeBuilder {
     private String function = "";
 
     public InjectBuilder(ResponseBuilder responseBuilder) {

--- a/javabank-core/src/main/java/org/mbtest/javabank/fluent/InjectBuilder.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/fluent/InjectBuilder.java
@@ -1,0 +1,21 @@
+package org.mbtest.javabank.fluent;
+
+import org.mbtest.javabank.http.responses.Inject;
+
+public class InjectBuilder extends AbstractResponseBuilder {
+    private String function = "";
+
+    public InjectBuilder(ResponseBuilder responseBuilder) {
+        super(responseBuilder);
+    }
+
+    public InjectBuilder function(String function) {
+        this.function = function;
+        return this;
+    }
+
+    @Override
+    protected Inject build() {
+        return new Inject().withFunction(function);
+    }
+}

--- a/javabank-core/src/main/java/org/mbtest/javabank/fluent/IsBuilder.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/fluent/IsBuilder.java
@@ -9,8 +9,7 @@ import java.util.HashMap;
 
 import static com.google.common.collect.Maps.newHashMap;
 
-public class IsBuilder implements FluentBuilder {
-    private ResponseBuilder parent;
+public class IsBuilder extends AbstractResponseBuilder {
     private int statusCode = 200;
     private String body = "";
     private String mode;
@@ -18,7 +17,7 @@ public class IsBuilder implements FluentBuilder {
     private final HashMap<String, String> headers = newHashMap();
 
     public IsBuilder(ResponseBuilder responseBuilder) {
-        this.parent = responseBuilder;
+        super(responseBuilder);
     }
 
     public IsBuilder statusCode(int statusCode) {
@@ -46,10 +45,6 @@ public class IsBuilder implements FluentBuilder {
         return this;
     }
 
-    public ResponseBuilder end() {
-        return parent;
-    }
-
     protected Is build() {
 
         if (this.bodyFile != null) {
@@ -61,7 +56,10 @@ public class IsBuilder implements FluentBuilder {
             }
         }
 
-        Is is = new Is().withStatusCode(statusCode).withHeaders(headers).withBody(body).withMode(mode);
-        return is;
+        return new Is()
+                .withStatusCode(statusCode)
+                .withHeaders(headers)
+                .withBody(body)
+                .withMode(mode);
     }
 }

--- a/javabank-core/src/main/java/org/mbtest/javabank/fluent/IsBuilder.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/fluent/IsBuilder.java
@@ -1,6 +1,6 @@
 package org.mbtest.javabank.fluent;
 
-import org.mbtest.javabank.http.core.Is;
+import org.mbtest.javabank.http.responses.Is;
 
 import java.io.File;
 import java.io.IOException;

--- a/javabank-core/src/main/java/org/mbtest/javabank/fluent/IsBuilder.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/fluent/IsBuilder.java
@@ -9,7 +9,7 @@ import java.util.HashMap;
 
 import static com.google.common.collect.Maps.newHashMap;
 
-public class IsBuilder extends AbstractResponseBuilder {
+public class IsBuilder extends ResponseTypeBuilder {
     private int statusCode = 200;
     private String body = "";
     private String mode;

--- a/javabank-core/src/main/java/org/mbtest/javabank/fluent/IsBuilder.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/fluent/IsBuilder.java
@@ -45,6 +45,7 @@ public class IsBuilder extends AbstractResponseBuilder {
         return this;
     }
 
+    @Override
     protected Is build() {
 
         if (this.bodyFile != null) {

--- a/javabank-core/src/main/java/org/mbtest/javabank/fluent/ResponseBuilder.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/fluent/ResponseBuilder.java
@@ -1,17 +1,18 @@
 package org.mbtest.javabank.fluent;
 
-import org.mbtest.javabank.http.core.Is;
+import java.util.HashMap;
 
 public class ResponseBuilder implements FluentBuilder {
     private StubBuilder parent;
-    private IsBuilder isBuilder;
+    private AbstractResponseBuilder builder;
 
     protected ResponseBuilder(StubBuilder stubBuilder) {
         this.parent = stubBuilder;
     }
 
     public IsBuilder is() {
-        isBuilder = new IsBuilder(this);
+        IsBuilder isBuilder = new IsBuilder(this);
+        builder = isBuilder;
         return isBuilder;
     }
 
@@ -20,8 +21,8 @@ public class ResponseBuilder implements FluentBuilder {
         return parent;
     }
 
-    protected Is build() {
-        if(isBuilder != null) return isBuilder.build();
+    protected HashMap build() {
+        if(builder != null) return builder.build();
 
         return new IsBuilder(this).build();
     }

--- a/javabank-core/src/main/java/org/mbtest/javabank/fluent/ResponseBuilder.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/fluent/ResponseBuilder.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 
 public class ResponseBuilder implements FluentBuilder {
     private StubBuilder parent;
-    private AbstractResponseBuilder builder;
+    private ResponseTypeBuilder builder;
 
     protected ResponseBuilder(StubBuilder stubBuilder) {
         this.parent = stubBuilder;

--- a/javabank-core/src/main/java/org/mbtest/javabank/fluent/ResponseBuilder.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/fluent/ResponseBuilder.java
@@ -1,6 +1,6 @@
 package org.mbtest.javabank.fluent;
 
-import java.util.HashMap;
+import org.mbtest.javabank.http.responses.Response;
 
 public class ResponseBuilder implements FluentBuilder {
     private StubBuilder parent;
@@ -25,7 +25,7 @@ public class ResponseBuilder implements FluentBuilder {
         return parent;
     }
 
-    protected HashMap build() {
+    protected Response build() {
         if(builder != null) return builder.build();
 
         return new IsBuilder(this).build();

--- a/javabank-core/src/main/java/org/mbtest/javabank/fluent/ResponseBuilder.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/fluent/ResponseBuilder.java
@@ -11,9 +11,13 @@ public class ResponseBuilder implements FluentBuilder {
     }
 
     public IsBuilder is() {
-        IsBuilder isBuilder = new IsBuilder(this);
-        builder = isBuilder;
-        return isBuilder;
+        builder = new IsBuilder(this);
+        return (IsBuilder) builder;
+    }
+
+    public InjectBuilder inject() {
+        builder = new InjectBuilder(this);
+        return (InjectBuilder) builder;
     }
 
     @Override

--- a/javabank-core/src/main/java/org/mbtest/javabank/fluent/ResponseTypeBuilder.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/fluent/ResponseTypeBuilder.java
@@ -2,10 +2,10 @@ package org.mbtest.javabank.fluent;
 
 import java.util.HashMap;
 
-public abstract class AbstractResponseBuilder implements FluentBuilder {
+public abstract class ResponseTypeBuilder implements FluentBuilder {
     private ResponseBuilder parent;
 
-    protected AbstractResponseBuilder(ResponseBuilder parent) {
+    protected ResponseTypeBuilder(ResponseBuilder parent) {
         this.parent = parent;
     }
 

--- a/javabank-core/src/main/java/org/mbtest/javabank/fluent/ResponseTypeBuilder.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/fluent/ResponseTypeBuilder.java
@@ -1,6 +1,6 @@
 package org.mbtest.javabank.fluent;
 
-import java.util.HashMap;
+import org.mbtest.javabank.http.responses.Response;
 
 public abstract class ResponseTypeBuilder implements FluentBuilder {
     private ResponseBuilder parent;
@@ -14,5 +14,5 @@ public abstract class ResponseTypeBuilder implements FluentBuilder {
         return parent;
     }
 
-    abstract protected HashMap build();
+    abstract protected Response build();
 }

--- a/javabank-core/src/main/java/org/mbtest/javabank/http/core/Stub.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/http/core/Stub.java
@@ -2,6 +2,7 @@ package org.mbtest.javabank.http.core;
 
 import org.mbtest.javabank.http.predicates.Predicate;
 import org.mbtest.javabank.http.responses.Is;
+import org.mbtest.javabank.http.responses.Response;
 
 import java.util.HashMap;
 import java.util.List;
@@ -25,7 +26,7 @@ public class Stub extends HashMap {
         return this;
     }
 
-    public Stub addResponse(HashMap response) {
+    public Stub addResponse(Response response) {
         getResponses().add(response);
 
         return this;
@@ -36,8 +37,8 @@ public class Stub extends HashMap {
         return this;
     }
 
-    public List<HashMap> getResponses() {
-        return (List<HashMap>) this.get(RESPONSES);
+    public List<Response> getResponses() {
+        return (List<Response>) this.get(RESPONSES);
     }
 
     public List<Predicate> getPredicates() {

--- a/javabank-core/src/main/java/org/mbtest/javabank/http/core/Stub.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/http/core/Stub.java
@@ -1,6 +1,7 @@
 package org.mbtest.javabank.http.core;
 
 import org.mbtest.javabank.http.predicates.Predicate;
+import org.mbtest.javabank.http.responses.Is;
 
 import java.util.HashMap;
 import java.util.List;

--- a/javabank-core/src/main/java/org/mbtest/javabank/http/core/Stub.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/http/core/Stub.java
@@ -24,7 +24,7 @@ public class Stub extends HashMap {
         return this;
     }
 
-    public Stub addResponse(Is response) {
+    public Stub addResponse(HashMap response) {
         getResponses().add(response);
 
         return this;
@@ -35,15 +35,15 @@ public class Stub extends HashMap {
         return this;
     }
 
-    public List<Is> getResponses() {
-        return (List<Is>) this.get(RESPONSES);
+    public List<HashMap> getResponses() {
+        return (List<HashMap>) this.get(RESPONSES);
     }
 
     public List<Predicate> getPredicates() {
         return (List<Predicate>) this.get(PREDICATES);
     }
 
-    public Is getResponse(int index) {
+    public HashMap getResponse(int index) {
         return getResponses().get(index);
     }
 

--- a/javabank-core/src/main/java/org/mbtest/javabank/http/responses/Inject.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/http/responses/Inject.java
@@ -1,0 +1,26 @@
+package org.mbtest.javabank.http.responses;
+
+import org.json.simple.JSONObject;
+
+import java.util.HashMap;
+
+public class Inject extends HashMap {
+    public static final String INJECT = "inject";
+
+    public Inject() {
+        this.put(INJECT, "");
+    }
+
+    public Inject withFunction(String function) {
+        this.put(INJECT, function);
+        return this;
+    }
+
+    public String toString() {
+        return getJSON().toJSONString();
+    }
+
+    public JSONObject getJSON() {
+        return new JSONObject(this);
+    }
+}

--- a/javabank-core/src/main/java/org/mbtest/javabank/http/responses/Inject.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/http/responses/Inject.java
@@ -1,10 +1,6 @@
 package org.mbtest.javabank.http.responses;
 
-import org.json.simple.JSONObject;
-
-import java.util.HashMap;
-
-public class Inject extends HashMap {
+public class Inject extends Response {
     public static final String INJECT = "inject";
 
     public Inject() {
@@ -14,13 +10,5 @@ public class Inject extends HashMap {
     public Inject withFunction(String function) {
         this.put(INJECT, function);
         return this;
-    }
-
-    public String toString() {
-        return getJSON().toJSONString();
-    }
-
-    public JSONObject getJSON() {
-        return new JSONObject(this);
     }
 }

--- a/javabank-core/src/main/java/org/mbtest/javabank/http/responses/Is.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/http/responses/Is.java
@@ -2,7 +2,6 @@ package org.mbtest.javabank.http.responses;
 
 import com.google.common.net.HttpHeaders;
 import org.apache.http.HttpStatus;
-import org.json.simple.JSONObject;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -10,7 +9,7 @@ import java.util.Objects;
 
 import static com.google.common.collect.Maps.newHashMap;
 
-public class Is extends HashMap {
+public class Is extends Response {
     public static final String IS = "is";
     public static final String HEADERS = "headers";
     public static final String BODY = "body";
@@ -59,20 +58,6 @@ public class Is extends HashMap {
             this.data.put(MODE, mode);
         }
         return this;
-    }
-
-    public String toString() {
-        return toJSON().toJSONString();
-    }
-
-    private JSONObject toJSON() {
-        JSONObject jsonObject = new JSONObject();
-        jsonObject.putAll(this);
-        return jsonObject;
-    }
-
-    public JSONObject getJSON() {
-        return new JSONObject(this);
     }
 
     public Is withHeaders(HashMap<String, String> headers) {

--- a/javabank-core/src/main/java/org/mbtest/javabank/http/responses/Is.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/http/responses/Is.java
@@ -1,4 +1,4 @@
-package org.mbtest.javabank.http.core;
+package org.mbtest.javabank.http.responses;
 
 import com.google.common.net.HttpHeaders;
 import org.apache.http.HttpStatus;

--- a/javabank-core/src/main/java/org/mbtest/javabank/http/responses/Response.java
+++ b/javabank-core/src/main/java/org/mbtest/javabank/http/responses/Response.java
@@ -1,0 +1,16 @@
+package org.mbtest.javabank.http.responses;
+
+import org.json.simple.JSONObject;
+
+import java.util.HashMap;
+
+public abstract class Response extends HashMap {
+
+    public JSONObject getJSON() {
+        return new JSONObject(this);
+    }
+
+    public String toString() {
+        return getJSON().toJSONString();
+    }
+}

--- a/javabank-core/src/test/java/org/mbtest/javabank/fluent/ImposterBuilderTest.java
+++ b/javabank-core/src/test/java/org/mbtest/javabank/fluent/ImposterBuilderTest.java
@@ -46,7 +46,7 @@ public class ImposterBuilderTest {
             .end()
         .build();
 
-        Is actualIs = imposter.getStub(0).getResponse(0);
+        Is actualIs = (Is)imposter.getStub(0).getResponse(0);
 
         assertThat(actualIs.getBody()).isEqualTo(expectedBody);
         assertThat(actualIs.getStatusCode()).isEqualTo(expectedStatusCode);

--- a/javabank-core/src/test/java/org/mbtest/javabank/fluent/ImposterBuilderTest.java
+++ b/javabank-core/src/test/java/org/mbtest/javabank/fluent/ImposterBuilderTest.java
@@ -2,11 +2,11 @@ package org.mbtest.javabank.fluent;
 
 import com.google.common.net.HttpHeaders;
 import org.junit.Test;
-import org.mbtest.javabank.http.core.Is;
 import org.mbtest.javabank.http.core.Stub;
 import org.mbtest.javabank.http.imposters.Imposter;
 import org.mbtest.javabank.http.predicates.Predicate;
 import org.mbtest.javabank.http.predicates.PredicateType;
+import org.mbtest.javabank.http.responses.Is;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javabank-core/src/test/java/org/mbtest/javabank/fluent/InjectBuilderTest.java
+++ b/javabank-core/src/test/java/org/mbtest/javabank/fluent/InjectBuilderTest.java
@@ -1,0 +1,5 @@
+package org.mbtest.javabank.fluent;
+
+public class InjectBuilderTest {
+
+}

--- a/javabank-core/src/test/java/org/mbtest/javabank/fluent/InjectBuilderTest.java
+++ b/javabank-core/src/test/java/org/mbtest/javabank/fluent/InjectBuilderTest.java
@@ -1,5 +1,28 @@
 package org.mbtest.javabank.fluent;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.mbtest.javabank.http.responses.Inject;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.mock;
+
 public class InjectBuilderTest {
 
+    private InjectBuilder injectBuilder;
+
+    @Before
+    public void setUp() throws Exception {
+        injectBuilder = new InjectBuilder(mock(ResponseBuilder.class));
+    }
+
+    @Test
+    public void shouldBuildAnInjectWithAFunction() throws Exception {
+        String injection = "some function";
+        Inject expectedInject = new Inject().withFunction(injection);
+        Inject actualInject = injectBuilder.function(injection).build();
+
+        assertThat(actualInject, is(expectedInject));
+    }
 }

--- a/javabank-core/src/test/java/org/mbtest/javabank/fluent/IsBuilderTest.java
+++ b/javabank-core/src/test/java/org/mbtest/javabank/fluent/IsBuilderTest.java
@@ -1,7 +1,7 @@
 package org.mbtest.javabank.fluent;
 
 import org.junit.Test;
-import org.mbtest.javabank.http.core.Is;
+import org.mbtest.javabank.http.responses.Is;
 
 import java.io.File;
 

--- a/javabank-core/src/test/java/org/mbtest/javabank/fluent/ResponseBuilderTest.java
+++ b/javabank-core/src/test/java/org/mbtest/javabank/fluent/ResponseBuilderTest.java
@@ -1,0 +1,50 @@
+package org.mbtest.javabank.fluent;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.HashMap;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class ResponseBuilderTest {
+
+    StubBuilder parent;
+    ResponseBuilder responseBuilder;
+
+    @Before
+    public void setUp() throws Exception {
+        parent = mock(StubBuilder.class);
+        responseBuilder = new ResponseBuilder(parent);
+    }
+
+    @Test
+    public void shouldConstructAnIsBuilderWithItselfAsTheParent() throws Exception {
+        IsBuilder isBuilder = responseBuilder.is();
+
+        assertThat(isBuilder.end(), is(responseBuilder));
+    }
+
+    @Test
+    public void shouldEndWithItsParent() throws Exception {
+        assertThat(responseBuilder.end(), is(parent));
+    }
+
+    @Test
+    public void shouldBuildAnEmptyIsByDefault() throws Exception {
+        HashMap expectedIs = new IsBuilder(responseBuilder).build();
+
+        assertThat(responseBuilder.build(), is(expectedIs));
+    }
+
+    @Test
+    public void shouldBuildAnIs() throws Exception {
+        IsBuilder isBuilder = responseBuilder.is();
+        isBuilder.body("some file");
+        HashMap expectedIs = isBuilder.build();
+
+        assertThat(responseBuilder.build(), is(expectedIs));
+    }
+}

--- a/javabank-core/src/test/java/org/mbtest/javabank/fluent/ResponseBuilderTest.java
+++ b/javabank-core/src/test/java/org/mbtest/javabank/fluent/ResponseBuilderTest.java
@@ -47,4 +47,13 @@ public class ResponseBuilderTest {
 
         assertThat(responseBuilder.build(), is(expectedIs));
     }
+
+    @Test
+    public void shouldBuildAnInject() throws Exception {
+        InjectBuilder injectBuilder = responseBuilder.inject();
+        injectBuilder.function("some function");
+        HashMap expectedInject = injectBuilder.build();
+
+        assertThat(responseBuilder.build(), is(expectedInject));
+    }
 }

--- a/javabank-core/src/test/java/org/mbtest/javabank/fluent/ResponseTypeBuilderTest.java
+++ b/javabank-core/src/test/java/org/mbtest/javabank/fluent/ResponseTypeBuilderTest.java
@@ -1,0 +1,39 @@
+package org.mbtest.javabank.fluent;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mbtest.javabank.http.responses.Response;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+public class ResponseTypeBuilderTest {
+
+    private ResponseBuilder parent;
+    private ResponseTypeBuilder responseTypeBuilder;
+
+    @Before
+    public void setUp() throws Exception {
+        parent = mock(ResponseBuilder.class);
+        responseTypeBuilder = new TestResponseBuilder(parent);
+
+    }
+
+    @Test
+    public void shouldEndWithItsParent() throws Exception {
+        assertThat(responseTypeBuilder.end(), is(parent));
+    }
+
+    private class TestResponseBuilder extends ResponseTypeBuilder {
+
+        TestResponseBuilder(ResponseBuilder parent) {
+            super(parent);
+        }
+
+        @Override
+        protected Response build() {
+            return null;
+        }
+    }
+}

--- a/javabank-core/src/test/java/org/mbtest/javabank/http/core/IsTest.java
+++ b/javabank-core/src/test/java/org/mbtest/javabank/http/core/IsTest.java
@@ -6,7 +6,7 @@ import org.apache.http.HttpStatus;
 import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
-import org.mbtest.javabank.fluent.IsBuilder;
+import org.mbtest.javabank.http.responses.Is;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javabank-core/src/test/java/org/mbtest/javabank/http/core/StubTest.java
+++ b/javabank-core/src/test/java/org/mbtest/javabank/http/core/StubTest.java
@@ -1,6 +1,7 @@
 package org.mbtest.javabank.http.core;
 
 import org.junit.Test;
+import org.mbtest.javabank.http.responses.Is;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javabank-core/src/test/java/org/mbtest/javabank/http/imposters/ImposterTest.java
+++ b/javabank-core/src/test/java/org/mbtest/javabank/http/imposters/ImposterTest.java
@@ -6,8 +6,8 @@ import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import org.mbtest.javabank.fluent.ImposterBuilder;
-import org.mbtest.javabank.http.core.Is;
 import org.mbtest.javabank.http.core.Stub;
+import org.mbtest.javabank.http.responses.Is;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/javabank-core/src/test/java/org/mbtest/javabank/http/responses/InjectTest.java
+++ b/javabank-core/src/test/java/org/mbtest/javabank/http/responses/InjectTest.java
@@ -1,0 +1,34 @@
+package org.mbtest.javabank.http.responses;
+
+import org.json.simple.JSONObject;
+import org.junit.Test;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+
+public class InjectTest {
+
+    public static final String FUNCTION = "some javascript function to be eval'd";
+
+    @Test
+    public void shouldCreateAJsonObject() throws Exception {
+        JSONObject expectedJson = new JSONObject();
+        expectedJson.put("inject", FUNCTION);
+
+        Inject inject = new Inject()
+                .withFunction(FUNCTION);
+
+        assertThat(inject.getJSON(), is(expectedJson));
+    }
+
+    @Test
+    public void shouldCreateAJsonString() throws Exception {
+        JSONObject expectedJson = new JSONObject();
+        expectedJson.put("inject", FUNCTION);
+
+        Inject inject = new Inject()
+                .withFunction(FUNCTION);
+
+        assertThat(inject.toString(), is(expectedJson.toJSONString()));
+    }
+}


### PR DESCRIPTION
Added a FluentBuilder that can construct an `inject` response, as well as a model object to create JSON for the request to mountebank. The model itself only consists of a single field containing a string, it is up to the user to make sure that string is something mountebank can work with. 

Most of the work was putting the Is/IsBuilder behind abstract classes so that the Inject/InjectBuilder could plug in nicely. For the two builders involved, I opted for an abstract class over an interface to maintain the convention of `end()` being public and `build()` being protected in the fluent builders. I'm not super committed to this because I don't know exactly why those access levels were put in.

I would love your feedback, and to take another pass at it if needed. Example usage can be found in ClientTest.java.
